### PR TITLE
Added endpoint and object reference for backups scheduling

### DIFF
--- a/_data/endpoints/linodes.yaml
+++ b/_data/endpoints/linodes.yaml
@@ -114,7 +114,11 @@ endpoints:
             curl -H "Content-Type: application/json" \
                 -H "Authorization: token $TOKEN" \
                 -X PUT -d '{
-                  "label": "newlabel"
+                  "label": "newlabel",
+                  "schedule": {
+                    "day": "Tuesday",
+                    "window": "W20"
+                  }
                 }' \
                 https://$api_root/$version/linodes/$linode_id
           python: |

--- a/_data/objects/linode.yaml
+++ b/_data/objects/linode.yaml
@@ -52,10 +52,22 @@ schema:
         _value: 80
         _description: Threshold as a percentage of your quota
   backups:
-    _description: Displays if backups are enabled, and last backup datetime if applicable
+    _description: >
+      Displays if backups are enabled, last backup datetime if applicable, and
+      the day/window your backups will occur. Window is prefixed by a "W" and an
+      integer representing the two-hour window in 24-hour time format. For example,
+      11AM is represented as "W11", 8PM as "W20", etc
     enabled:
       _type: boolean
       _value: true
+    schedule:
+      _description: The day and window of a Linode's automatic backups
+      day:
+        _type: string
+        _value: "Tuesday"
+      window:
+        _type: string
+        _value: "W20"
     last_backup:
       _description: If enabled, when last backup was successfully completed
       create_dt:


### PR DESCRIPTION
Linode object reference now updated, including description of
how to set window

PUT /linodes/:id endpoint shows example of updating schedule
